### PR TITLE
.NET 6.0 対応 (AzukiTest を除く)

### DIFF
--- a/Ann/Ann.Net6.csproj
+++ b/Ann/Ann.Net6.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<RootNamespace>Sgry.Ann</RootNamespace>	  
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Azuki\Azuki.Net6.csproj" />
+  </ItemGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+	  <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
+	</ItemGroup>
+</Project>

--- a/Ann/AnnForm.cs
+++ b/Ann/AnnForm.cs
@@ -628,20 +628,39 @@ namespace Sgry.Ann
 			// _StatusBar
 			//
 			_StatusBar.Dock = DockStyle.Bottom;
+			#if NET6_0
+			_StatusBar.Items.AddRange( new ToolStripStatusLabel[] {
+				_Status_Message, _Status_CaretPos,
+				_Status_SelectionMode, _Status_InsertionMode
+			});
+			_Status_Message.BorderSides = ToolStripStatusLabelBorderSides.Right;
+			_Status_CaretPos.BorderSides = ToolStripStatusLabelBorderSides.Right;
+			_Status_SelectionMode.BorderSides = ToolStripStatusLabelBorderSides.Right;
+			_Status_InsertionMode.BorderSides = ToolStripStatusLabelBorderSides.Right;
+			#else
 			_StatusBar.Panels.AddRange( new StatusBarPanel[] {
 				_Status_Message, _Status_CaretPos,
 				_Status_SelectionMode, _Status_InsertionMode
 			});
 			_StatusBar.ShowPanels = true;
 			_StatusBar.SizingGrip = true;
+			#endif
 			//
 			// _Status_CaretPos
 			//
+			#if NET6_0
+			_Status_CaretPos.Alignment = ToolStripItemAlignment.Right;
+			#else
 			_Status_CaretPos.Alignment = HorizontalAlignment.Right;
+			#endif
 			//
 			// _Status_Message
 			//
+			#if NET6_0
+			_Status_Message.Spring = true;
+			#else
 			_Status_Message.AutoSize = StatusBarPanelAutoSize.Spring;
+			#endif
 			//
 			// _MI_File
 			//
@@ -955,11 +974,19 @@ namespace Sgry.Ann
 		AzukiControl _Azuki;
 		TabPanel<Document> _TabPanel = new TabPanel<Document>();
 		SearchPanel _SearchPanel = new SearchPanel();
+		#if NET6_0
+		StatusStrip _StatusBar = new StatusStrip();
+		ToolStripStatusLabel _Status_Message = new ToolStripStatusLabel();
+		ToolStripStatusLabel _Status_CaretPos = new ToolStripStatusLabel();
+		ToolStripStatusLabel _Status_SelectionMode = new ToolStripStatusLabel();
+		ToolStripStatusLabel _Status_InsertionMode = new ToolStripStatusLabel();
+		#else
 		StatusBar _StatusBar = new StatusBar();
 		StatusBarPanel _Status_Message = new StatusBarPanel();
 		StatusBarPanel _Status_CaretPos = new StatusBarPanel();
 		StatusBarPanel _Status_SelectionMode = new StatusBarPanel();
 		StatusBarPanel _Status_InsertionMode = new StatusBarPanel();
+		#endif
 		#endregion
 
 		#region Utilities

--- a/Azuki.Net6.sln
+++ b/Azuki.Net6.sln
@@ -1,0 +1,41 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30330.147
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azuki.Net6", "Azuki\Azuki.Net6.csproj", "{FDE3E32C-011D-4DE7-BDFD-7B33A6AD5694}"
+EndProject
+#Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzukiTest.Net6", "AzukiTest\AzukiTest.Net6.csproj", "{B65928CC-264F-424E-9AD6-A977D62FB2A3}"
+#EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ann.Net6", "Ann\Ann.Net6.csproj", "{E26EF2E6-0D3C-441C-A971-1CDC176B8AE6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FDE3E32C-011D-4DE7-BDFD-7B33A6AD5694}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FDE3E32C-011D-4DE7-BDFD-7B33A6AD5694}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDE3E32C-011D-4DE7-BDFD-7B33A6AD5694}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FDE3E32C-011D-4DE7-BDFD-7B33A6AD5694}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B65928CC-264F-424E-9AD6-A977D62FB2A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B65928CC-264F-424E-9AD6-A977D62FB2A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B65928CC-264F-424E-9AD6-A977D62FB2A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B65928CC-264F-424E-9AD6-A977D62FB2A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E26EF2E6-0D3C-441C-A971-1CDC176B8AE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E26EF2E6-0D3C-441C-A971-1CDC176B8AE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E26EF2E6-0D3C-441C-A971-1CDC176B8AE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E26EF2E6-0D3C-441C-A971-1CDC176B8AE6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {53E05B1C-A400-4753-8B81-12FABFA54E50}
+	EndGlobalSection
+	GlobalSection(SubversionScc) = preSolution
+		Svn-Managed = True
+		Manager = AnkhSVN - Subversion Support for Visual Studio
+	EndGlobalSection
+EndGlobal

--- a/Azuki/Azuki.Net6.csproj
+++ b/Azuki/Azuki.Net6.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+
+	<ItemGroup>
+	  <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+	</ItemGroup>
+	
+</Project>


### PR DESCRIPTION
.NET 6.0 で Azuki と Ann のビルドを通しました。
StatusBar が廃止されたため、Ann は StatusBar/StatusBarPanel を StatusStrip/ToolStripStatusLabel に置き換えました。
AzukiTest はエラー多数のため未対応です。
